### PR TITLE
Create extract Changelog to a separate file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Datatrans Changelog
+
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+
+## 3.0.2 - 2014-01-04
+-------
+### Added
+* Specified MIT License.
+
+## 3.0.0 - 2013-09-25
+-------
+### Changed
+* Refactored code to allow multiple configurations
+* Proxy config now uses HTTParty naming convention.
+
+## 2.2.2 - 2011-10-11
+-------
+### Added
+
+* ability to skip signing by setting `config.sign_key = false`
+
+## 1.0.0 - 2011-07-07
+---
+
+Initial release
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,25 +5,26 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 4.0.0 - 2022-02-25
+### Changed
+* [BREAKING CHANGE] Bump minimum required Ruby version to 2.6 and Rails to 5.2 (@andyundso #34)
+* Change Datatrans hostnames (@rgisiger #32)
+
 ## 3.0.2 - 2014-01-04
--------
 ### Added
 * Specified MIT License.
 
 ## 3.0.0 - 2013-09-25
--------
 ### Changed
 * Refactored code to allow multiple configurations
 * Proxy config now uses HTTParty naming convention.
 
 ## 2.2.2 - 2011-10-11
--------
 ### Added
 
 * ability to skip signing by setting `config.sign_key = false`
 
 ## 1.0.0 - 2011-07-07
----
 
 Initial release
 

--- a/README.markdown
+++ b/README.markdown
@@ -149,24 +149,6 @@ To make an authorized transaction invalid use void.
       # transaction.error_code, transaction.error_message, transaction.error_detail
     end
 
-
-CHANGELOG
-=========
-
-3.0.2
--------
-Specified MIT License.
-
-3.0.0
--------
-* Refactored Code to allow multiple configurations
-* Proxy config now uses HTTParty naming convention.
-
-2.2.2
--------
-* added ability to skip signing by setting config.sign_key = false
-
-
 Todo
 ====
 


### PR DESCRIPTION
This PR adds a `Changelog` to the project. There were [more versions](https://rubygems.org/gems/datatrans/versions) in the gem's history, but since we don't know the exact changes for each of them, I haven't included them into Changelog.