### PR TITLE
Add release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
           ruby-version: 2.7
       - name: Tag on Github
         run: |
-          VERSION=$(ruby -e "puts Gem::Specification::load('keycloak_oauth.gemspec').version")
+          VERSION=$(ruby -e "puts Gem::Specification::load('datatrans.gemspec').version")
           echo "v$VERSION"
           git tag "v$VERSION"
           git push origin "v$VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+---
+name: Tag on Github and Release to RubyGems
+on: [workflow_dispatch]
+
+jobs:
+  release:
+    name: Release to RubyGems
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+      - name: Tag on Github
+        run: |
+          VERSION=$(ruby -e "puts Gem::Specification::load('keycloak_oauth.gemspec').version")
+          echo "v$VERSION"
+          git tag "v$VERSION"
+          git push origin "v$VERSION"
+      - name: Publish to RubyGems
+        run: |
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          printf -- "---\n:rubygems_api_key: ${RUBYGEMS_API_KEY}\n" > $HOME/.gem/credentials
+          gem build *.gemspec
+          gem push *.gem
+        env:
+          RUBYGEMS_API_KEY: ${{secrets.RUBYGEMS_API_KEY}}


### PR DESCRIPTION
This commit add a pipeline which allows us to release the gem automated. First, it'll push a tag to Github according to what is written in `version.rb`. Afterwards, it'll push the new gem release to RubyGems.