### PR TITLE
Authenticate requests with Basic Auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+* [BREAKING CHANGE] Authenticate requests with HTTP Basic Auth (@crackofdusk [#41](https://github.com/simplificator/datatrans/pull/41))
+
+  Datatrans requires [HTTP Basic Auth for XML API calls](https://api-reference.datatrans.ch/xml/#authentication-tls) since 2022-09-14 ([announcement](https://mailchi.mp/datatrans/basic-authsign2_1-email_en))
+
 ## 4.0.1 - 2022-03-18
 ### Fixed
 * Check for successful transaction depends on `status` and not on `response_message` that can be diferent for different payment methods (@schmijos [#8](https://github.com/simplificator/datatrans/pull/8) and @TatianaPan [#39](https://github.com/simplificator/datatrans/pull/39))

--- a/README.markdown
+++ b/README.markdown
@@ -11,6 +11,7 @@ Build your Datatrans Configuration like so:
     datatrans = Datatrans::Config.new(
       :merchant_id => '1234567',
       :sign_key => 'ab739fd5b7c2a1...',
+      :password => 'server to server request password',
       :environment => :production,
       :proxy => {
         :http_proxyaddr => "proxy.com",

--- a/lib/datatrans/config.rb
+++ b/lib/datatrans/config.rb
@@ -11,10 +11,11 @@ module Datatrans
     }
     DOMAIN = 'datatrans.com'
 
-    attr_reader :environment, :merchant_id, :sign_key, :proxy
+    attr_reader :environment, :merchant_id, :sign_key, :password, :proxy
 
     # Configure with following options
     # * :merchant_id (required)
+    # * :password (required)
     # * :sign_key (defaults to false)
     # * :environment (defaults to :development, available environments are defined in ENVIRONMENTS)
     # * :proxy (a hash containing :http_proxyaddr, :http_proxyport, :http_proxyuser, :http_proxypass)
@@ -22,6 +23,8 @@ module Datatrans
       @merchant_id = options[:merchant_id]
       raise ArgumentError.new(":merchant_id is required") unless self.merchant_id
       self.environment = options[:environment] || DEFAULT_ENVIRONMENT
+      @password = options[:password]
+      raise ArgumentError.new(":password is required") unless self.password
       @sign_key = options[:sign_key] || DEFAULT_SIGN_KEY
       @proxy = options[:proxy] || {}
     end

--- a/lib/datatrans/xml/transaction/request.rb
+++ b/lib/datatrans/xml/transaction/request.rb
@@ -7,7 +7,9 @@ class Datatrans::XML::Transaction
     attr_accessor :params, :datatrans
 
     def post(url, options = {})
-      options = options.merge(self.datatrans.proxy)
+      options = options
+        .merge(self.datatrans.proxy)
+        .merge(:basic_auth => { :username => self.datatrans.merchant_id, :password => self.datatrans.password })
       HTTParty.post(url, **options)
     end
 

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Datatrans::Config do
   describe "Instance Methods" do
     before do
-      @datatrans = Datatrans::Config.new(:merchant_id => "xxx")
+      @datatrans = Datatrans::Config.new(:merchant_id => "xxx", :password => "yyy")
     end
 
     describe "web_transaction" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,7 @@ RSpec.configure do |config|
     @datatrans = Datatrans::Config.new(
       :merchant_id => '1100000000',
       :sign_key => 'd777c17ba2010282c2d2350a68b441ca07a799d294bfaa630b7c8442207c0b69703cc55775b0ca5a4e455b818a9bb10a43669c0c20ce31f4a43f10e0cabb9525',
+      :password => 'basic_auth_password',
       :environment => :development
     )
   end

--- a/spec/xml/request_spec.rb
+++ b/spec/xml/request_spec.rb
@@ -7,6 +7,7 @@ describe Datatrans::XML::Transaction::Request do
         @datatrans = Datatrans::Config.new(
           :merchant_id => '1100000000',
           :sign_key => 'd777c17ba2010282c2d2350a68b441ca07a799d294bfaa630b7c8442207c0b69703cc55775b0ca5a4e455b818a9bb10a43669c0c20ce31f4a43f10e0cabb9525',
+          :password => 'basic_auth_password',
           :key => "value",
           :proxy => {
             :http_proxyaddr => "proxy.com",
@@ -21,6 +22,7 @@ describe Datatrans::XML::Transaction::Request do
       it "forward those options to HTTParty" do
         request = Datatrans::XML::Transaction::Request.new(@datatrans, {})
         expect(HTTParty).to receive(:post).with('lirum',
+         :basic_auth => {:password => 'basic_auth_password', :username => '1100000000'},
          :params => {:foo => :bar},
            :http_proxpass => 'xxx',
            :http_proxyuser => 'hans',
@@ -33,7 +35,7 @@ describe Datatrans::XML::Transaction::Request do
     describe "not configured" do
       it "should not add any proxy settings" do
         request = Datatrans::XML::Transaction::Request.new(@datatrans, {})
-        expect(HTTParty).to receive(:post).with('lirum', :params => {:foo => :bar})
+        expect(HTTParty).to receive(:post).with('lirum', :basic_auth => {:password => 'basic_auth_password', :username => '1100000000'}, :params => {:foo => :bar})
         request.post('lirum', :params => {:foo => :bar})
       end
     end


### PR DESCRIPTION
As of 14th September 2022, requests to the XML API must be authenticated with HTTP Basic Auth.

Documentation: https://api-reference.datatrans.ch/xml/#authentication-tls
Announcement: https://mailchi.mp/datatrans/basic-authsign2_1-email_en