### PR TITLE
Prepare release 5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 5.1.0 - 2023-06-12
+
 ### Added
 
-* Add support for Datatrans JSON API
+* Add support for Datatrans JSON API (@TatianaPan [#45](https://github.com/simplificator/datatrans/pull/45)). Check Readme for details on how to use it.
+
+XML API is [deprecated](https://mailchi.mp/datatrans/basic-authdynamic-sign_reminder) by Datatrans and will not be supported by them after June 3rd, 2024. Consider to moving to a [new JSON API](https://api-reference.datatrans.ch/).
 
 ## 5.0.0 - 2022-09-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## 5.1.0 - 2023-06-12
+## 5.1.0 - 2023-07-06
 
 ### Added
 
+* Test against Ruby 3.2 (@andyundso [#43](https://github.com/simplificator/datatrans/pull/43))
 * Add support for Datatrans JSON API (@TatianaPan [#45](https://github.com/simplificator/datatrans/pull/45)). Check Readme for details on how to use it.
 
 XML API is [deprecated](https://mailchi.mp/datatrans/basic-authdynamic-sign_reminder) by Datatrans and will not be supported by them after June 3rd, 2024. Consider to moving to a [new JSON API](https://api-reference.datatrans.ch/).

--- a/lib/datatrans/config.rb
+++ b/lib/datatrans/config.rb
@@ -75,6 +75,11 @@ module Datatrans
     end
 
     def xml_transaction(*args)
+      message = <<-WARNING
+      [WARNING] Usage of XML API is deprecated by Datatrans. Consider moving to JSON API until June 3rd, 2024.
+      WARNING
+
+      Warning.warn(message)
       XML::Transaction.new(self, *args)
     end
 

--- a/lib/datatrans/config.rb
+++ b/lib/datatrans/config.rb
@@ -75,11 +75,6 @@ module Datatrans
     end
 
     def xml_transaction(*args)
-      message = <<-WARNING
-      [WARNING] Usage of XML API is deprecated by Datatrans. Consider moving to JSON API until June 3rd, 2024.
-      WARNING
-
-      Warning.warn(message)
       XML::Transaction.new(self, *args)
     end
 

--- a/lib/datatrans/version.rb
+++ b/lib/datatrans/version.rb
@@ -1,3 +1,3 @@
 module Datatrans
-  VERSION = "5.0.0"
+  VERSION = "5.1.0"
 end


### PR DESCRIPTION
Since we now support JSON API, let's ship a new minor version (it's not a breaking change, that's why a minor)