### PR TITLE
Add support for manual settlements

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -139,7 +139,7 @@ Once you have a transaction id, you can start a transaction. Users of your appli
  render js: "window.location='#{path}'"
 ```
 
-You do not have to [settle a transaction](https://api-reference.datatrans.ch/#tag/v1transactions/operation/settle) by yourself: we set `"autoSettle": true` by default when authorizing a transaction, which means the transaction will be settled automatically.
+You do not have to [settle a transaction](https://api-reference.datatrans.ch/#tag/v1transactions/operation/settle) by yourself: we set `"autoSettle": true` by default when authorizing a transaction, which means the transaction will be settled automatically. This can be overridden by setting `auto_settle: false` when authorizing a transaction.
 
 Transaction status
 ------------------

--- a/lib/datatrans/json/transaction/authorize.rb
+++ b/lib/datatrans/json/transaction/authorize.rb
@@ -25,11 +25,13 @@ class Datatrans::JSON::Transaction
     end
 
     def request_body
+      auto_settle = params[:auto_settle].nil? ? true : params[:auto_settle]
+
       {
         "currency": params[:currency],
         "refno": params[:refno],
         "amount": params[:amount],
-        "autoSettle": true,
+        "autoSettle": auto_settle,
         "paymentMethods": params[:payment_methods],
         "redirect": {
           "successUrl": params[:success_url],

--- a/spec/json/authorize_spec.rb
+++ b/spec/json/authorize_spec.rb
@@ -23,6 +23,19 @@ describe Datatrans::JSON::Transaction::Authorize do
       error_url: "https://pay.sandbox.datatrans.com/upp/merchant/errorPage.jsp"
     }
 
+    @expected_request_body = {
+      "currency": "CHF",
+      "refno": "B4B4B4B4B",
+      "amount": 1337,
+      "autoSettle": true,
+      "paymentMethods": ["ECA", "VIS"],
+      "redirect": {
+        "successUrl": "https://pay.sandbox.datatrans.com/upp/merchant/successPage.jsp",
+        "cancelUrl": "https://pay.sandbox.datatrans.com/upp/merchant/cancelPage.jsp",
+        "errorUrl": "https://pay.sandbox.datatrans.com/upp/merchant/errorPage.jsp"
+      }
+    }
+
     @invalid_params = {
       currency: "CHF",
       refno: nil,
@@ -37,26 +50,24 @@ describe Datatrans::JSON::Transaction::Authorize do
     end
 
     it "generates correct request_body" do
-      expected = {
-        "currency": "CHF",
-        "refno": "B4B4B4B4B",
-        "amount": 1337,
-        "autoSettle": true,
-        "paymentMethods": ["ECA", "VIS"],
-        "redirect": {
-          "successUrl": "https://pay.sandbox.datatrans.com/upp/merchant/successPage.jsp",
-          "cancelUrl": "https://pay.sandbox.datatrans.com/upp/merchant/cancelPage.jsp",
-          "errorUrl": "https://pay.sandbox.datatrans.com/upp/merchant/errorPage.jsp"
-        }
-      }
       request = Datatrans::JSON::Transaction::Authorize.new(@datatrans, @valid_params)
 
-      expect(request.request_body).to eq(expected)
+      expect(request.request_body).to eq(@expected_request_body)
     end
 
     it "#process handles a valid datatrans authorize response" do
       @transaction = Datatrans::JSON::Transaction.new(@datatrans, @valid_params)
       expect(@transaction.authorize).to be true
+    end
+  end
+
+  context "with autoSettle specified" do
+    it "uses autoSettle=false in request_body" do
+      params_with_auto_settle = @valid_params.merge(auto_settle: false)
+      request = Datatrans::JSON::Transaction::Authorize.new(@datatrans, params_with_auto_settle)
+
+      expected_request_body_without_auto_settle = @expected_request_body.merge(autoSettle: false)
+      expect(request.request_body).to eq(expected_request_body_without_auto_settle)
     end
   end
 


### PR DESCRIPTION
Currently, transactions are auto-settled by default. However, in some cases, settlement of transactions should be delayed. This adds support for that, allowing setting `auto_settle: false` when authorizing a transaction.

```ruby
transaction = datatrans.json_transaction(
  refno: 'ABCDEF',
  amount: 1000,
  # ...,
  auto_settle: false
)
``` 