### PR TITLE
Add `JSON::Transaction::Settle`

### DIFF
--- a/lib/datatrans/config.rb
+++ b/lib/datatrans/config.rb
@@ -63,6 +63,10 @@ module Datatrans
         # https://api.sandbox.datatrans.com/v1/transactions/{transactionId}
         subdomain = SUBDOMAINS[:server_to_server_api]
         path = "/v1/transactions/#{options[:transaction_id]}"
+      when :json_settle_url
+        # https://api.sandbox.datatrans.com/v1/transactions/{transactionId}/settle
+        subdomain = SUBDOMAINS[:server_to_server_api]
+        path = "/v1/transactions/#{options[:transaction_id]}/settle"
       else
         raise "Unknown wanted action '#{what}'."
       end

--- a/lib/datatrans/json/transaction.rb
+++ b/lib/datatrans/json/transaction.rb
@@ -22,6 +22,12 @@ module Datatrans::JSON
       @response.successful?
     end
 
+    def settle
+      self.request = Settle.new(self.datatrans, params)
+      @response = SettleResponse.new(self.datatrans, request.process)
+      @response.successful?
+    end
+
     def transaction_path
       self.datatrans.url(:start_json_transaction, transaction_id: params[:transaction_id])
     end
@@ -30,3 +36,4 @@ end
 
 require 'datatrans/json/transaction/authorize'
 require 'datatrans/json/transaction/status'
+require 'datatrans/json/transaction/settle'

--- a/lib/datatrans/json/transaction/settle.rb
+++ b/lib/datatrans/json/transaction/settle.rb
@@ -1,0 +1,41 @@
+require 'httparty'
+require 'datatrans/json/transaction/response'
+
+class Datatrans::JSON::Transaction
+  class Settle
+    # Class to settle a transaction https://api-reference.datatrans.ch/#tag/v1transactions/operation/settle
+    attr_accessor :params, :datatrans
+
+    def initialize(datatrans, params)
+      @datatrans = datatrans
+      @params = params
+    end
+
+    def post(url, options = {})
+      options = options
+        .merge(self.datatrans.proxy)
+        .merge(:basic_auth => { :username => self.datatrans.merchant_id, :password => self.datatrans.password })
+      HTTParty.post(url, **options)
+    end
+
+    def process
+      post(self.datatrans.url(:json_settle_url, transaction_id: params[:transaction_id]),
+        :headers => { 'Content-Type' => 'application/json' },
+        :body => request_body.to_json).parsed_response
+    end
+
+    def request_body
+      {
+        "currency": params[:currency],
+        "amount": params[:amount],
+        "refno": params[:refno]
+      }
+    end
+  end
+
+  class SettleResponse < Response
+    def successful?
+      params["error"].blank?
+    end
+  end
+end

--- a/spec/json/settle_spec.rb
+++ b/spec/json/settle_spec.rb
@@ -1,0 +1,55 @@
+require "spec_helper"
+
+describe Datatrans::JSON::Transaction::Settle do
+  before do
+    @valid_params_authorize = {
+      currency: "CHF",
+      refno: "B4B4B4B4B",
+      amount: 1337,
+      payment_methods: ["ECA", "VIS"],
+      success_url: "https://pay.sandbox.datatrans.com/upp/merchant/successPage.jsp",
+      cancel_url: "https://pay.sandbox.datatrans.com/upp/merchant/cancelPage.jsp",
+      error_url: "https://pay.sandbox.datatrans.com/upp/merchant/errorPage.jsp"
+    }
+
+    @valid_params_settle = {
+      transaction_id: '230223022302230223',
+      amount: 1337,
+      currency: "CHF",
+      refno: "B4B4B4B4B"
+    }
+
+    @successful_response_settle = {} # Empty hash as 204 No Content is expected for successful settlement
+
+    @failed_response_settle = {
+      "error" => {
+        "code" => "INVALID_REQUEST",
+        "message" => "Invalid transaction ID or parameters"
+      }
+    }
+  end
+
+  context "successful response" do
+    before do
+      allow_any_instance_of(Datatrans::JSON::Transaction::Settle).to receive(:process).and_return(@successful_response_settle)
+    end
+
+    it "handles a successful settle request" do
+      transaction = Datatrans::JSON::Transaction.new(@datatrans, @valid_params_settle)
+      expect(transaction.settle).to be true
+    end
+  end
+
+  context "failed response" do
+    before do
+      allow_any_instance_of(Datatrans::JSON::Transaction::Settle).to receive(:process).and_return(@failed_response_settle)
+    end
+
+    it "handles a failed settle request" do
+      transaction = Datatrans::JSON::Transaction.new(@datatrans, @valid_params_settle)
+      expect(transaction.settle).to be false
+      expect(transaction.response.error_code).to eq "INVALID_REQUEST"
+      expect(transaction.response.error_message).to eq "Invalid transaction ID or parameters"
+    end
+  end
+end


### PR DESCRIPTION
This allows settling transactions via the corresponding [`settle`](https://api-reference.datatrans.ch/#tag/v1transactions/operation/settle) operation. This is useful when using `auto_settle: false` during authorization.