### PR TITLE
Prepare to release v5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 5.2.0 - 2024-01-31
+
+### Added
+
+* Support for Ruby 3.3 and Rails 7.1 (@andyundso [#47](https://github.com/simplificator/datatrans/pull/47))
+* Support for Merchant Initiated Payments (@visini [#48](https://github.com/simplificator/datatrans/pull/48), [#52](https://github.com/simplificator/datatrans/pull/52), [#53](https://github.com/simplificator/datatrans/pull/53), [#56](https://github.com/simplificator/datatrans/pull/56))
+
+### Changed
+
+* Reformatted code with standardrb (@andyundso [#57](https://github.com/simplificator/datatrans/pull/57))
+* Marked XML APIs and Web APIs as deprecated (@andyundso [#60](https://github.com/simplificator/datatrans/pull/60))
+* Renamed `Datatrans::JSON::Transaction::Authorize` to `Datatrans::JSON::Transaction::Init`. `::Authorize` will still work until the next major release (@andyundso [#60](https://github.com/simplificator/datatrans/pull/60))
+
 ## 5.1.0 - 2023-07-06
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    datatrans (5.1.0)
+    datatrans (5.2.0)
       activesupport (>= 5.2)
       builder
       httparty
@@ -41,8 +41,8 @@ GEM
     diff-lcs (1.5.0)
     docile (1.4.0)
     erubi (1.10.0)
-    httparty (0.20.0)
-      mime-types (~> 3.0)
+    httparty (0.21.0)
+      mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
@@ -52,9 +52,7 @@ GEM
     loofah (2.16.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mime-types (3.4.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2022.0105)
+    mini_mime (1.1.5)
     mini_portile2 (2.8.5)
     minitest (5.15.0)
     multi_xml (0.6.0)

--- a/lib/datatrans/version.rb
+++ b/lib/datatrans/version.rb
@@ -1,3 +1,3 @@
 module Datatrans
-  VERSION = "5.1.0"
+  VERSION = "5.2.0"
 end


### PR DESCRIPTION
This PR adds the necessary `CHANGELOG` entries and version bump for the next version of the Datatrans gem.