### PR TITLE
Lock bundler version below v2.5

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,12 @@
         "ruby"
       ],
       "enabled": false
+    },
+    {
+      "matchPackageNames": [
+        "bundler"
+      ],
+      "allowedVersions": "<2.5"
     }
   ]
 }


### PR DESCRIPTION
v2.5 dropped support for Ruby 2.6:
https://github.com/rubygems/rubygems/blob/HEAD/bundler/CHANGELOG.md#250-december-15-2023