### PR TITLE
Add support for TWINT params

### DIFF
--- a/lib/datatrans/json/transaction/merchant_authorize.rb
+++ b/lib/datatrans/json/transaction/merchant_authorize.rb
@@ -27,13 +27,17 @@ class Datatrans::JSON::Transaction
     def request_body
       auto_settle = params[:auto_settle].nil? ? true : params[:auto_settle]
 
-      {
+      body = {
         currency: params[:currency],
         refno: params[:refno],
         amount: params[:amount],
-        card: params[:card],
         autoSettle: auto_settle
       }
+
+      body[:card] = params[:card] if params[:card].present?
+      body[:TWI] = params[:TWI] if params[:TWI].present?
+
+      body
     end
   end
 

--- a/spec/json/merchant_authorize_spec.rb
+++ b/spec/json/merchant_authorize_spec.rb
@@ -29,6 +29,16 @@ describe Datatrans::JSON::Transaction::MerchantAuthorize do
       auto_settle: true
     }
 
+    @valid_params_twint = {
+      currency: "CHF",
+      refno: "B4B4B4B4B",
+      amount: 1000,
+      TWI: {
+        alias: "123456"
+      },
+      auto_settle: true
+    }
+
     @expected_request_body = {
       currency: "CHF",
       refno: "B4B4B4B4B",
@@ -37,6 +47,16 @@ describe Datatrans::JSON::Transaction::MerchantAuthorize do
         alias: "AAABcH0Bq92s3kgAESIAAbGj5NIsAHWC",
         expiryMonth: "01",
         expiryYear: "23"
+      },
+      autoSettle: true
+    }
+
+    @expected_request_body_twint = {
+      currency: "CHF",
+      refno: "B4B4B4B4B",
+      amount: 1000,
+      TWI: {
+        alias: "123456"
       },
       autoSettle: true
     }
@@ -75,6 +95,14 @@ describe Datatrans::JSON::Transaction::MerchantAuthorize do
 
       expected_request_body_without_auto_settle = @expected_request_body.merge(autoSettle: false)
       expect(request.request_body).to eq(expected_request_body_without_auto_settle)
+    end
+  end
+
+  context "with TWI specified" do
+    it "handles TWI correctly in request_body" do
+      request = Datatrans::JSON::Transaction::MerchantAuthorize.new(@datatrans, @valid_params_twint)
+
+      expect(request.request_body).to eq(@expected_request_body_twint)
     end
   end
 


### PR DESCRIPTION
To support [merchant-initiated payments](https://api-reference.datatrans.ch/#tag/v1transactions/operation/authorize) for the payment method TWINT (`TWI`), the alias needs to be passed in the request body as `body["TWI"]["alias"]`, as defined by `TwintAuthorizeRequest`. This PR adds support for that.