### PR TITLE
Allow passing additional params to json_transaction

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -101,6 +101,7 @@ JSON Transactions
 =================
 
 More information about Datatrans JSON API can be found [here](https://api-reference.datatrans.ch/). Our gem uses endpoints from `/v1/transactions` section. 
+You can set any additional properties like custom webhook URLs in the json payload by passing `additional_options: <your options>`.
 
 We implemented support for [Redirect mode](https://docs.datatrans.ch/docs/redirect-lightbox) (since Lightbox mode may not work correctly on mobile, whereas Redirect works well on all devices).
 

--- a/README.markdown
+++ b/README.markdown
@@ -101,7 +101,6 @@ JSON Transactions
 =================
 
 More information about Datatrans JSON API can be found [here](https://api-reference.datatrans.ch/). Our gem uses endpoints from `/v1/transactions` section. 
-You can set any additional properties like custom webhook URLs in the json payload by passing `additional_options: <your options>`.
 
 We implemented support for [Redirect mode](https://docs.datatrans.ch/docs/redirect-lightbox) (since Lightbox mode may not work correctly on mobile, whereas Redirect works well on all devices).
 
@@ -142,6 +141,10 @@ if init
   transaction_id = transaction.response.params["transactionId"]
 end
 ```
+
+You can set any additional properties like custom webhook URLs in the json payload by passing `additional_options: <your options>`.
+See the API documentation for all available options [here](https://api-reference.datatrans.ch/). 
+
 
 Start a transaction
 -------------------

--- a/lib/datatrans/json/transaction/init.rb
+++ b/lib/datatrans/json/transaction/init.rb
@@ -41,7 +41,7 @@ class Datatrans::JSON::Transaction
       }
 
       body["option"] = params[:option] if params[:option].present?
-      body.merge!(params[:additional_options]) if params[:additional_options].present?
+      body.deep_merge!(params[:additional_options]) if params[:additional_options].present?
 
       body
     end

--- a/lib/datatrans/json/transaction/init.rb
+++ b/lib/datatrans/json/transaction/init.rb
@@ -41,6 +41,7 @@ class Datatrans::JSON::Transaction
       }
 
       body["option"] = params[:option] if params[:option].present?
+      body.merge!(params[:additional_options]) if params[:additional_options].present?
 
       body
     end

--- a/spec/json/init_spec.rb
+++ b/spec/json/init_spec.rb
@@ -81,6 +81,19 @@ describe Datatrans::JSON::Transaction::Init do
     end
   end
 
+  context "with additional_options specified" do
+    it "uses option in request_body" do
+      params_with_option = @valid_params.merge(additional_options:         { webhook: {
+        url: 'https://datatrans-test-webhook.ch/webhook'
+      }})
+      request = Datatrans::JSON::Transaction::Init.new(@datatrans, params_with_option)
+
+      expected_request_body_with_options = @expected_request_body.merge(webhook: {url:
+                                                                                   'https://datatrans-test-webhook.ch/webhook'})
+      expect(request.request_body).to eq(expected_request_body_with_options)
+    end
+  end
+
   context "failed response" do
     before do
       allow_any_instance_of(Datatrans::JSON::Transaction::Init).to receive(:process).and_return(@failed_response)

--- a/spec/json/init_spec.rb
+++ b/spec/json/init_spec.rb
@@ -83,13 +83,13 @@ describe Datatrans::JSON::Transaction::Init do
 
   context "with additional_options specified" do
     it "uses option in request_body" do
-      params_with_option = @valid_params.merge(additional_options:         { webhook: {
-        url: 'https://datatrans-test-webhook.ch/webhook'
+      params_with_option = @valid_params.merge(additional_options:         {webhook: {
+        url: "https://datatrans-test-webhook.ch/webhook"
       }})
       request = Datatrans::JSON::Transaction::Init.new(@datatrans, params_with_option)
 
       expected_request_body_with_options = @expected_request_body.merge(webhook: {url:
-                                                                                   'https://datatrans-test-webhook.ch/webhook'})
+                                                                                   "https://datatrans-test-webhook.ch/webhook"})
       expect(request.request_body).to eq(expected_request_body_with_options)
     end
   end

--- a/spec/json/init_spec.rb
+++ b/spec/json/init_spec.rb
@@ -82,7 +82,7 @@ describe Datatrans::JSON::Transaction::Init do
   end
 
   context "with additional_options specified" do
-    it "uses option in request_body" do
+    it "uses additional_options in request_body" do
       params_with_option = @valid_params.merge(additional_options:         {webhook: {
         url: "https://datatrans-test-webhook.ch/webhook"
       }})
@@ -90,6 +90,23 @@ describe Datatrans::JSON::Transaction::Init do
 
       expected_request_body_with_options = @expected_request_body.merge(webhook: {url:
                                                                                    "https://datatrans-test-webhook.ch/webhook"})
+      expect(request.request_body).to eq(expected_request_body_with_options)
+    end
+  end
+
+  context "with additional_options with redirect specified" do
+    it "uses additional_options in request_body" do
+      params_with_option = @valid_params.merge(additional_options:         {redirect: {
+        method: "POST"
+      }})
+      request = Datatrans::JSON::Transaction::Init.new(@datatrans, params_with_option)
+
+      expected_request_body_with_options = @expected_request_body.merge(redirect: {
+        successUrl: "https://pay.sandbox.datatrans.com/upp/merchant/successPage.jsp",
+        cancelUrl: "https://pay.sandbox.datatrans.com/upp/merchant/cancelPage.jsp",
+        errorUrl: "https://pay.sandbox.datatrans.com/upp/merchant/errorPage.jsp",
+        method: "POST"
+      })
       expect(request.request_body).to eq(expected_request_body_with_options)
     end
   end

--- a/spec/json/transaction_spec.rb
+++ b/spec/json/transaction_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe Datatrans::JSON::Transaction do
-  it "returns correct trasaction_path" do
+  it "returns correct transaction_path" do
     params = {transaction_id: "230223022302230223"}
     transaction = Datatrans::JSON::Transaction.new(@datatrans, params)
 


### PR DESCRIPTION
Hello,

Thank you for this cool project. 
I added a param to the json_transaction that allows setting all parameters in the transaction request to the datatrans api. My use case is that I want to use different webhook endpoints during development/QA without creating multiple datatrans testaccounts. With this new option any json param can be sent to the /transactions endpoint.

Let me know if this works for you.

Best Regards
